### PR TITLE
fixed animation for tech stack

### DIFF
--- a/src/components/TechStack/TechStack.js
+++ b/src/components/TechStack/TechStack.js
@@ -54,13 +54,13 @@ export default function TechStack() {
           <div className="ts-item ts-js">
             <div className="ts-box">
               <img src={logo_javascript} alt="JavaScript logo" />
-              <p>JavaScript ES6</p>
+              <p>Java<br></br>Script<br></br>ES6</p>
             </div>
           </div>
           <div className="ts-item ts-firebase">
             <div className="ts-box">
               <img src={logo_firebase} alt="Firebase logo" />
-              <p>Firebase</p>
+              <p>Fire<br></br>base</p>
             </div>
           </div>
           <div className="ts-item ts-html">

--- a/src/components/TechStack/TechStack.scss
+++ b/src/components/TechStack/TechStack.scss
@@ -50,9 +50,13 @@ $transitionTime: 0.75s;
   background-color: #ce679a;
 }
 .ts-box {
-  visibility: hidden;
+  opacity: 0;
   text-align: center;
   color: #ffffff;
+  & p {
+    background-color: #0000009e;
+    padding: 3px 4px;
+  }
   img {
     width: 64px;
     height: 64px;
@@ -68,8 +72,8 @@ $transitionTime: 0.75s;
     width:100%;
     transition: width $transitionTime;
     .ts-box {
-      visibility: visible;
-      transition-delay: 0.5s;
+      opacity: 1;
+      transition: opacity 1s;
     }
   }
 }


### PR DESCRIPTION
<img width="917" alt="image" src="https://user-images.githubusercontent.com/82684763/213605055-067cf46a-9a01-4923-ba38-6119db7d679a.png">

Looks much nicer with background behind tech stack item names and fade in effect.